### PR TITLE
CC-321 Deploy to virtual machine

### DIFF
--- a/.github/workflows/submodule.yaml
+++ b/.github/workflows/submodule.yaml
@@ -1,4 +1,4 @@
-name: Update submodule in control-room
+name: Build package & update submodule in control-room
 
 on:
   push:
@@ -6,7 +6,38 @@ on:
       - main
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile.prod
+          push: true
+          tags: ghcr.io/cityconnect-tqs/digital-signage:latest
+          platforms: "linux/amd64,linux/arm64"
+
   submodule:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -1,2 +1,3 @@
-export const BASE_API_URL = "http://api.localhost/api/public/";
-export const WS_API_URL = "ws://api.localhost/api/public/ws";
+const VITE_HOST_URL = import.meta.env.VITE_HOST_URL as string;
+export const BASE_API_URL = `http://api.${VITE_HOST_URL}/api/public/`;
+export const WS_API_URL = `ws://api.${VITE_HOST_URL}/api/public/ws`;


### PR DESCRIPTION
This PR builds a ghcr.io package every time a push is made to the main branch, right before committing in the control-room repo. This package is used for deploy.

Also, this PR enables specifying the host URL from the environment.